### PR TITLE
Fix incorrect Nan check in interp_nans

### DIFF
--- a/AstroBkgInterp.py
+++ b/AstroBkgInterp.py
@@ -481,16 +481,24 @@ class AstroBkgInterp():
         return bkg
 
     def interp_nans(self, data):
-        """Interpolate the value of a NaN pixel using its neighbors.
+        """Interpolate NaN pixels using neighboring pixels.
+
+        Replaces NaN values in input data with a median of their
+        neighboring values in a 3x3 window centered around the NaN. If all
+        neighbors are NaN, the value is set to 0. Edge cases are handled to
+        ensure window does not go out of bounds.
         
         Parameters:
         -----------
         data : 2D numpy array
+            Input data containing NaNs.
         
         Returns:
         -----------
         newdata : 2D numpy array
-            nan-interpolated copy of input array
+            Modified copy of the input data where NaNs have been replaced
+            by either their local median or zero, where no valid neighbors
+            exist.
         """
         m,n = data.shape
         newdata = np.copy(data)
@@ -498,8 +506,14 @@ class AstroBkgInterp():
         for j in range(m):
             for i in range(n):
                 if np.isnan(data[j,i]):
-                    med = np.nanmedian(data[j-1:j+2,i-1:i+2])
+                    # Define bounds to avoid index errors
+                    j_min, j_max = max(j - 1, 0), min(j + 2, m)
+                    i_min, i_max = max(i - 1, 0), min(i + 2, n)
 
+                    # Compute median of neighbouring pixels, ignoring NaNs
+                    med = np.nanmedian(data[j_min:j_max, i_min:i_max])
+
+                    # Assign median, else zero if no valid neighbors
                     if np.isnan(med):
                         newdata[j,i] = 0
                     else:   

--- a/AstroBkgInterp.py
+++ b/AstroBkgInterp.py
@@ -492,22 +492,18 @@ class AstroBkgInterp():
         newdata : 2D numpy array
             nan-interpolated copy of input array
         """
-
         m,n = data.shape
-        newdata = np.zeros_like(data)
+        newdata = np.copy(data)
 
         for j in range(m):
             for i in range(n):
                 if np.isnan(data[j,i]):
-                    
                     med = np.nanmedian(data[j-1:j+2,i-1:i+2])
-                    
-                    if med == np.nan:
+
+                    if np.isnan(med):
                         newdata[j,i] = 0
                     else:   
-                        newdata[j,i] = np.nanmedian(data[j-1:j+2,i-1:i+2])
-                else:
-                    newdata[j,i] = data[j,i]
+                        newdata[j,i] = med
 
         return newdata
     


### PR DESCRIPTION
Fixes the loop in `interp_nans` such that when the median of neighboring values is NaN/ no valid neighbors exist, the value is replaced with zero. It also adds boundary conditions to ensure indices remain within valid limits.

- Uses `np.isnan(med)` instead of `med == np.nan` for proper NaN detection.
- Eliminates redundant re-calculation of median (`med`) during loop.
- Creates `newdata` as a copy of `data` instead of an all-zero array. Preserves original values and saves copying the unfiltered values back into the newdata array.
- Handles edge cases to ensure the window does not go out of bounds.
- Complete docstrings

Fixes issue #16 and #15.


Screenshots
-------------
<img width="413" alt="Screenshot 2025-03-19 at 5 28 47 PM" src="https://github.com/user-attachments/assets/bf0b0fcb-d6ec-4f0c-a125-5a1845921179" />
